### PR TITLE
ci: temporarily disable comprenhensive checks during active development

### DIFF
--- a/.github/workflows/R-CMD-check-dev.yaml
+++ b/.github/workflows/R-CMD-check-dev.yaml
@@ -11,7 +11,7 @@ on:
       - 'LICENSE'
       - 'NEWS.md'
   push:
-    branches: [dev]
+    branches: [master, dev]
     paths-ignore:
       - '**/README.md'
       - '**.nix'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [none] # TODO: switch back to master when v2 is ready
     paths-ignore:
       - '**/README.md'
       - '**.nix'


### PR DESCRIPTION
The rlib/actions take a long time since they tend to compile most bioconductor packages. Every merge at this point needn't run the full battery