### PR TITLE
faster TFIDF

### DIFF
--- a/R/transformTFIDF.R
+++ b/R/transformTFIDF.R
@@ -1,11 +1,11 @@
-#' Transform/normalize compartment calls using TF-IDF
+#' Transform/normalize counts using TF-IDF
 #'
 #' @details
 #' This function and its helpers were modeled after or taken from:
 #' - http://andrewjohnhill.com/images/posts/2019-5-6-dimensionality-reduction-for-scatac-data/analysis.html
 #' - https://divingintogeneticsandgenomics.rbind.io/post/clustering-scatacseq-data-the-tf-idf-way/
 #'
-#' @param mat n x p input matrix (n = samples/cells; p = compartments)
+#' @param mat n x p input matrix (n = samples/cells; p = rna counts)
 #' @param scale.factor Scaling factor for the term-frequency (TF)
 #'
 #' @return A TF-IDF transformed matrix of the same dimensions as the input

--- a/man/transformTFIDF.Rd
+++ b/man/transformTFIDF.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/transformTFIDF.R
 \name{transformTFIDF}
 \alias{transformTFIDF}
-\title{Transform/normalize compartment calls using TF-IDF}
+\title{Transform/normalize counts using TF-IDF}
 \usage{
 transformTFIDF(mat, scale.factor = 100000)
 }
 \arguments{
-\item{mat}{n x p input matrix (n = samples/cells; p = compartments)}
+\item{mat}{n x p input matrix (n = samples/cells; p = rna counts)}
 
 \item{scale.factor}{Scaling factor for the term-frequency (TF)}
 }
@@ -15,7 +15,7 @@ transformTFIDF(mat, scale.factor = 100000)
 A TF-IDF transformed matrix of the same dimensions as the input
 }
 \description{
-Transform/normalize compartment calls using TF-IDF
+Transform/normalize counts using TF-IDF
 }
 \details{
 This function and its helpers were modeled after or taken from:


### PR DESCRIPTION
Fix documentation to say this is done on counts not on compartment calls
Should this be just counts or is there a better word?

Performance improvements:
- If `nrow > ncol` don't transpose since the next step also transposes. Only transpose if `nrow < ncol`
- Binarize a sparse matrix instead of the dense matrix
- Transpose the result matrix before making it dense

Potential further improvements:
- don't transpose the result matrix since it needs to be transposed again as input to compartment calling

Benchmark:
```
mat <- assay(fte_bigwig)
dim(mat)
# [1] 3088298     305

# old function
system.time(old <- transformTFIDF(mat))
#    user  system elapsed
#  22.034   3.807  25.950

# new function
system.time(new <- transformTFIDF(mat))
#    user  system elapsed
#   7.456   1.041   8.537

identical(old, new)
# [1] TRUE
```